### PR TITLE
add checks for valid sourcemaps

### DIFF
--- a/chrome/0001-add-tests-for-sourcemaps-spec.patch
+++ b/chrome/0001-add-tests-for-sourcemaps-spec.patch
@@ -1,7 +1,7 @@
 From 5a77ff79e4092740116e1c6871bd15fc5f560e66 Mon Sep 17 00:00:00 2001
 From: Agata Belkius <abelkius@gmail.com>
 Date: Fri, 19 Apr 2024 15:30:48 +0100
-Subject: [PATCH] add tests for sourcemaps spec
+Subject: [PATCH 1/2] add tests for sourcemaps spec
 
 ---
  front_end/BUILD.gn                            |   1 +

--- a/chrome/0001-add-tests-for-sourcemaps-spec.patch
+++ b/chrome/0001-add-tests-for-sourcemaps-spec.patch
@@ -1,7 +1,7 @@
 From 5a77ff79e4092740116e1c6871bd15fc5f560e66 Mon Sep 17 00:00:00 2001
 From: Agata Belkius <abelkius@gmail.com>
 Date: Fri, 19 Apr 2024 15:30:48 +0100
-Subject: [PATCH 1/2] add tests for sourcemaps spec
+Subject: [PATCH 1/3] add tests for sourcemaps spec
 
 ---
  front_end/BUILD.gn                            |   1 +

--- a/chrome/0002-add-test-for-valid-sourcemaps.patch
+++ b/chrome/0002-add-test-for-valid-sourcemaps.patch
@@ -1,7 +1,7 @@
 From ddcad1d602ba5201ebd8560b44731232114a0c9d Mon Sep 17 00:00:00 2001
 From: Agata Belkius <abelkius@gmail.com>
 Date: Tue, 30 Apr 2024 13:53:36 +0100
-Subject: [PATCH 2/2] add test for valid sourcemaps
+Subject: [PATCH 2/3] add test for valid sourcemaps
 
 ---
  front_end/core/sdk/SourceMapSpec.test.ts | 17 +++++++++++++----

--- a/chrome/0002-add-test-for-valid-sourcemaps.patch
+++ b/chrome/0002-add-test-for-valid-sourcemaps.patch
@@ -1,0 +1,59 @@
+From ddcad1d602ba5201ebd8560b44731232114a0c9d Mon Sep 17 00:00:00 2001
+From: Agata Belkius <abelkius@gmail.com>
+Date: Tue, 30 Apr 2024 13:53:36 +0100
+Subject: [PATCH 2/2] add test for valid sourcemaps
+
+---
+ front_end/core/sdk/SourceMapSpec.test.ts | 17 +++++++++++++----
+ 1 file changed, 13 insertions(+), 4 deletions(-)
+
+diff --git a/front_end/core/sdk/SourceMapSpec.test.ts b/front_end/core/sdk/SourceMapSpec.test.ts
+index 64f350d7f3..d8953d42fa 100644
+--- a/front_end/core/sdk/SourceMapSpec.test.ts
++++ b/front_end/core/sdk/SourceMapSpec.test.ts
+@@ -30,7 +30,7 @@
+ const {assert} = chai;
+ import type * as Platform from '../platform/platform.js';
+ import {assertNotNullOrUndefined} from '../platform/platform.js';
+-import { SourceMapV3 } from './SourceMap.js';
++import { SourceMapV3, parseSourceMap } from './SourceMap.js';
+ import * as SDK from './sdk.js';
+ import {describeWithEnvironment} from '../../testing/EnvironmentHelpers.js';
+ 
+@@ -62,21 +62,30 @@ describeWithEnvironment.only('SourceMapSpec', async () => {
+     testActions,
+     sourceMapIsValid
+   }) => {
+-    it(`checks mappings for ${sourceMapFile}`, async () => {
++    it(`tests ${sourceMapFile}`, async () => {
+       if (!sourceMapIsValid) {
++        // TODO - right now most of the failure scenarios are actually passing
+         return;
+       }
+       
++      // check if a valid sourcemap can be loaded and a SourceMap object created
+       const baseFileUrl = baseFile as Platform.DevToolsPath.UrlString;
+       const sourceMapFileUrl = sourceMapFile as Platform.DevToolsPath.UrlString;
+       const sourceMapContent = await loadSourceMapFromFixture(sourceMapFile);
+-
++      
++      assert.doesNotThrow(() => parseSourceMap(JSON.stringify(sourceMapContent)));
++      assert.doesNotThrow(() => new SDK.SourceMap.SourceMap(
++        baseFileUrl, 
++        sourceMapFileUrl, 
++        sourceMapContent
++      ));
++      
++      // check if the mappings are valid
+       const sourceMap = new SDK.SourceMap.SourceMap(
+         baseFileUrl, 
+         sourceMapFileUrl, 
+         sourceMapContent);
+     
+-      
+       if (testActions !== undefined) {
+         testActions.forEach(({
+           actionType,
+-- 
+2.39.3 (Apple Git-145)
+

--- a/chrome/0003-add-more-tests-cases.patch
+++ b/chrome/0003-add-more-tests-cases.patch
@@ -1,0 +1,108 @@
+From f07ac89859cef0b251c38310d0933092faf6a652 Mon Sep 17 00:00:00 2001
+From: Agata Belkius <abelkius@gmail.com>
+Date: Thu, 2 May 2024 11:09:27 +0100
+Subject: [PATCH 3/3] add more tests cases
+
+---
+ front_end/core/sdk/SourceMapSpec.test.ts | 65 +++++++++++++++++++++---
+ 1 file changed, 59 insertions(+), 6 deletions(-)
+
+diff --git a/front_end/core/sdk/SourceMapSpec.test.ts b/front_end/core/sdk/SourceMapSpec.test.ts
+index d8953d42fa..2d6818f785 100644
+--- a/front_end/core/sdk/SourceMapSpec.test.ts
++++ b/front_end/core/sdk/SourceMapSpec.test.ts
+@@ -60,18 +60,68 @@ describeWithEnvironment.only('SourceMapSpec', async () => {
+     baseFile,
+     sourceMapFile,
+     testActions,
+-    sourceMapIsValid
++    sourceMapIsValid,
++    name
+   }) => {
+     it(`tests ${sourceMapFile}`, async () => {
++      const consoleErrorSpy = sinon.spy(console, 'error');
++      const sourceMapContent = await loadSourceMapFromFixture(sourceMapFile);
++
++      // 1) check if an invalid sourcemap throws on SourceMap instance creation
++      if (!sourceMapIsValid && [
++        'sourcesMissing', 
++        'indexMapMissingOffset'
++      ].includes(name)) {
++        assert.throws(() => new SDK.SourceMap.SourceMap(
++          baseFile as Platform.DevToolsPath.UrlString, 
++          sourceMapFile as Platform.DevToolsPath.UrlString, 
++          sourceMapContent
++        ));
++        
++        return;
++      }
++
++      // 2) check if an invalid sourcemap throws on mapping creation
++      if (!sourceMapIsValid && [
++        'invalidVLQDueToNonBase64Character', 
++        'invalidMappingNotAString1',
++        'invalidMappingNotAString2',
++        'invalidMappingSegmentBadSeparator',
++        'invalidMappingSegmentWithZeroFields',
++        'invalidMappingSegmentWithTwoFields',
++        'invalidMappingSegmentWithThreeFields'
++      ].includes(name)) {
++        const sourceMap = new SDK.SourceMap.SourceMap(
++          baseFile as Platform.DevToolsPath.UrlString, 
++          sourceMapFile as Platform.DevToolsPath.UrlString, 
++          sourceMapContent
++        );
++        
++        // TODO - findEntry or just mappings should be used here? mappings is the culprit 
++        // but it is called from different other methods e.g: findEntry()
++        sourceMap.mappings();
++        assert.equal(consoleErrorSpy.calledWith("Failed to parse source map"), true);
++
++        return;
++      }
++
++      // 3) check if an invalid sourcemap can have the mapping created
+       if (!sourceMapIsValid) {
++        const sourceMap = new SDK.SourceMap.SourceMap(
++          baseFile as Platform.DevToolsPath.UrlString, 
++          sourceMapFile as Platform.DevToolsPath.UrlString, 
++          sourceMapContent
++        );
++        sourceMap.mappings();
+         // TODO - right now most of the failure scenarios are actually passing
+-        return;
++        assert.equal(consoleErrorSpy.notCalled, true);
++        console.warn('Invalid sourcemap passes basic validation');
+       }
++
+       
+-      // check if a valid sourcemap can be loaded and a SourceMap object created
++      // 4) check if a valid sourcemap can be parsed and a SourceMap instance created
+       const baseFileUrl = baseFile as Platform.DevToolsPath.UrlString;
+       const sourceMapFileUrl = sourceMapFile as Platform.DevToolsPath.UrlString;
+-      const sourceMapContent = await loadSourceMapFromFixture(sourceMapFile);
+       
+       assert.doesNotThrow(() => parseSourceMap(JSON.stringify(sourceMapContent)));
+       assert.doesNotThrow(() => new SDK.SourceMap.SourceMap(
+@@ -79,13 +129,16 @@ describeWithEnvironment.only('SourceMapSpec', async () => {
+         sourceMapFileUrl, 
+         sourceMapContent
+       ));
++
+       
+-      // check if the mappings are valid
++      // 5) check if the mappings are valid
+       const sourceMap = new SDK.SourceMap.SourceMap(
+         baseFileUrl, 
+         sourceMapFileUrl, 
+         sourceMapContent);
+-    
++        
++      assert.doesNotThrow(() => sourceMap.findEntry(1, 1));
++      
+       if (testActions !== undefined) {
+         testActions.forEach(({
+           actionType,
+-- 
+2.39.3 (Apple Git-145)
+


### PR DESCRIPTION
I just added assertions for valid sourcemaps.

I'd like to also add some for invalid sourcemaps but the devtools are very loose on allowing invalid sourcemapsto actually be attached anyway, so most of those test cases actually pass anyway - maybe something we could tackle during the hackathon.